### PR TITLE
Revamp purchase form with single-select and styling

### DIFF
--- a/public/index.html
+++ b/public/index.html
@@ -3,15 +3,20 @@
 <head>
   <meta charset="UTF-8" />
   <title>Shop</title>
+  <link rel="stylesheet" href="styles.css">
 </head>
 <body>
   <h1>Buy Products</h1>
-  <form id="purchaseForm">
-    <label for="products">Select products:</label>
-    <select id="products" multiple></select>
-    <div>Total: ¥<span id="total">0</span></div>
-    <button type="submit">Purchase</button>
-  </form>
+  <div class="form-card">
+    <form id="purchaseForm">
+      <label for="products">Select products:</label>
+      <select id="products">
+        <option value=""></option>
+      </select>
+      <div>Total: ¥<span id="total">0</span></div>
+      <button type="submit">Purchase</button>
+    </form>
+  </div>
   <script src="main.js"></script>
 </body>
 </html>

--- a/public/main.js
+++ b/public/main.js
@@ -13,9 +13,8 @@ async function loadProducts() {
 
 function updateTotal() {
   const select = document.getElementById('products');
-  const total = Array.from(select.selectedOptions).reduce((sum, option) => {
-    return sum + Number(option.dataset.price);
-  }, 0);
+  const option = select.value ? select.querySelector(`option[value="${select.value}"]`) : null;
+  const total = option ? Number(option.dataset.price) : 0;
   document.getElementById('total').textContent = String(total);
 }
 
@@ -24,14 +23,14 @@ document.getElementById('products').addEventListener('change', updateTotal);
 document.getElementById('purchaseForm').addEventListener('submit', async (e) => {
   e.preventDefault();
   const select = document.getElementById('products');
-  const items = Array.from(select.selectedOptions).map((o) => ({ productId: o.value, quantity: 1 }));
+  const items = [{ productId: select.value, quantity: 1 }];
   await fetch('/api/purchase', {
     method: 'POST',
     headers: { 'Content-Type': 'application/json' },
     body: JSON.stringify({ items }),
   });
   alert('Purchase recorded');
-  select.selectedIndex = -1;
+  select.value = '';
   updateTotal();
 });
 

--- a/public/styles.css
+++ b/public/styles.css
@@ -1,0 +1,57 @@
+body {
+  font-family: Arial, sans-serif;
+  background: #f1f3f4;
+  display: flex;
+  justify-content: center;
+  align-items: flex-start;
+  padding-top: 40px;
+  margin: 0;
+}
+
+.form-card {
+  background: #fff;
+  padding: 24px;
+  border-radius: 8px;
+  box-shadow: 0 2px 4px rgba(0, 0, 0, 0.2);
+  width: 100%;
+  max-width: 480px;
+}
+
+label {
+  display: block;
+  margin-top: 16px;
+  margin-bottom: 4px;
+  font-size: 16px;
+  color: #202124;
+}
+
+select {
+  width: 100%;
+  padding: 8px;
+  font-size: 16px;
+  border: 1px solid #dadce0;
+  border-radius: 4px;
+  background: #fff;
+}
+
+select:focus {
+  outline: none;
+  border-color: #1a73e8;
+  box-shadow: 0 0 0 1px #1a73e8;
+}
+
+button {
+  margin-top: 24px;
+  padding: 10px 16px;
+  font-size: 16px;
+  background: #1a73e8;
+  color: #fff;
+  border: none;
+  border-radius: 4px;
+  cursor: pointer;
+  transition: background 0.2s ease-in-out;
+}
+
+button:hover {
+  background: #1669c1;
+}


### PR DESCRIPTION
## Summary
- wrap purchase form in a styled card and link new stylesheet
- add Google-like form styling and simplify selection to single product
- adjust price calculation and submission to match single-select dropdown

## Testing
- `npm test && echo tests-ok`

------
https://chatgpt.com/codex/tasks/task_e_68a4227219d8832b8a1a93de033b4024