### PR TITLE
Implement phone-based balance tracking and charging flow

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,11 +5,9 @@ A simple TypeScript/Express application that records product purchases using Goo
 ## Features
 
 - Fetch products from a Google Sheet and display them on a purchase page.
-- Buyers select multiple products; the total price updates dynamically.
-- Purchases are recorded in a `Purchases` sheet for later review.
-- Admin dashboard shows sales summary per product without sending emails.
-
-The code is structured to allow future expansion such as prepaid balances linked to phone numbers.
+- Buyers can enter a phone number, see their balance and select multiple products with quantities; the total price updates dynamically and purchases are blocked when the balance is insufficient.
+- Purchases are recorded in a `Purchases` sheet and user balances are deducted in the `Users` sheet.
+- Admin pages show sales summaries and provide a simple interface to charge user balances.
 
 ## Setup
 
@@ -25,4 +23,4 @@ The code is structured to allow future expansion such as prepaid balances linked
    npm start
    ```
 
-Visit `http://localhost:3000` for the purchase page and `http://localhost:3000/admin.html` for the sales dashboard.
+Visit `http://localhost:3000` for the purchase page, `http://localhost:3000/admin.html` for the sales dashboard, and `http://localhost:3000/charge.html` to charge user balances.

--- a/public/charge.html
+++ b/public/charge.html
@@ -1,0 +1,21 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8" />
+  <title>Charge Balance</title>
+  <link rel="stylesheet" href="styles.css" />
+</head>
+<body>
+  <h1>Charge Balance</h1>
+  <div class="form-card">
+    <form id="chargeForm">
+      <label for="phone">Phone Number</label>
+      <input type="text" id="phone" />
+      <label for="amount">Amount</label>
+      <input type="number" id="amount" />
+      <button type="submit">Charge</button>
+    </form>
+  </div>
+  <script src="charge.js"></script>
+</body>
+</html>

--- a/public/charge.js
+++ b/public/charge.js
@@ -1,0 +1,17 @@
+document.getElementById('chargeForm').addEventListener('submit', async (e) => {
+  e.preventDefault();
+  const phone = document.getElementById('phone').value.trim();
+  const amount = Number(document.getElementById('amount').value);
+  const res = await fetch('/api/charge', {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify({ phoneNumber: phone, amount }),
+  });
+  if (res.ok) {
+    alert('Charged');
+    document.getElementById('amount').value = '';
+  } else {
+    const err = await res.json();
+    alert(err.error || 'Failed to charge');
+  }
+});

--- a/public/index.html
+++ b/public/index.html
@@ -3,16 +3,18 @@
 <head>
   <meta charset="UTF-8" />
   <title>Shop</title>
-  <link rel="stylesheet" href="styles.css">
+  <link rel="stylesheet" href="styles.css" />
 </head>
 <body>
   <h1>Buy Products</h1>
   <div class="form-card">
     <form id="purchaseForm">
-      <label for="products">Select products:</label>
-      <select id="products">
-        <option value=""></option>
-      </select>
+      <label for="phone">Phone Number</label>
+      <input type="text" id="phone" />
+      <div>Balance: ¥<span id="balance">0</span></div>
+
+      <div id="productList"></div>
+
       <div>Total: ¥<span id="total">0</span></div>
       <button type="submit">Purchase</button>
     </form>

--- a/public/main.js
+++ b/public/main.js
@@ -1,37 +1,82 @@
+let products = [];
+let balance = 0;
+
 async function loadProducts() {
   const res = await fetch('/api/products');
-  const products = await res.json();
-  const select = document.getElementById('products');
+  products = await res.json();
+  const container = document.getElementById('productList');
   products.forEach((p) => {
-    const option = document.createElement('option');
-    option.value = p.id;
-    option.textContent = `${p.name} - ¥${p.price}`;
-    option.dataset.price = p.price;
-    select.appendChild(option);
+    const div = document.createElement('div');
+    div.innerHTML = `<label>${p.name} - ¥${p.price} <input type="number" min="0" value="0" data-id="${p.id}" data-price="${p.price}" class="qty"></label>`;
+    container.appendChild(div);
   });
 }
 
 function updateTotal() {
-  const select = document.getElementById('products');
-  const option = select.value ? select.querySelector(`option[value="${select.value}"]`) : null;
-  const total = option ? Number(option.dataset.price) : 0;
+  let total = 0;
+  document.querySelectorAll('.qty').forEach((input) => {
+    const qty = Number(input.value);
+    const price = Number(input.dataset.price);
+    total += qty * price;
+  });
   document.getElementById('total').textContent = String(total);
+  const totalEl = document.getElementById('total');
+  if (balance < total) {
+    totalEl.classList.add('over');
+  } else {
+    totalEl.classList.remove('over');
+  }
 }
 
-document.getElementById('products').addEventListener('change', updateTotal);
+async function loadBalance() {
+  const phone = document.getElementById('phone').value.trim();
+  if (!phone) return;
+  const res = await fetch(`/api/balance/${encodeURIComponent(phone)}`);
+  const data = await res.json();
+  balance = data.balance;
+  document.getElementById('balance').textContent = String(balance);
+  updateTotal();
+}
+
+document.getElementById('productList').addEventListener('input', updateTotal);
+
+document.getElementById('phone').addEventListener('blur', loadBalance);
 
 document.getElementById('purchaseForm').addEventListener('submit', async (e) => {
   e.preventDefault();
-  const select = document.getElementById('products');
-  const items = [{ productId: select.value, quantity: 1 }];
-  await fetch('/api/purchase', {
+  const phone = document.getElementById('phone').value.trim();
+  const items = [];
+  document.querySelectorAll('.qty').forEach((input) => {
+    const qty = Number(input.value);
+    if (qty > 0) {
+      items.push({ productId: input.dataset.id, quantity: qty });
+    }
+  });
+  let total = 0;
+  items.forEach((item) => {
+    const product = products.find((p) => p.id === item.productId);
+    if (product) total += product.price * item.quantity;
+  });
+  if (balance < total) {
+    alert('Insufficient balance');
+    return;
+  }
+  const res = await fetch('/api/purchase', {
     method: 'POST',
     headers: { 'Content-Type': 'application/json' },
-    body: JSON.stringify({ items }),
+    body: JSON.stringify({ phoneNumber: phone, items }),
   });
-  alert('Purchase recorded');
-  select.value = '';
-  updateTotal();
+  if (res.ok) {
+    const data = await res.json();
+    balance = data.balance;
+    document.getElementById('balance').textContent = String(balance);
+    document.querySelectorAll('.qty').forEach((input) => (input.value = '0'));
+    updateTotal();
+    alert('Purchase recorded');
+  } else {
+    const err = await res.json();
+    alert(err.error || 'Failed to record purchase');
+  }
 });
 
 loadProducts();

--- a/public/styles.css
+++ b/public/styles.css
@@ -25,19 +25,29 @@ label {
   color: #202124;
 }
 
-select {
+input {
   width: 100%;
   padding: 8px;
   font-size: 16px;
   border: 1px solid #dadce0;
   border-radius: 4px;
+  box-sizing: border-box;
   background: #fff;
 }
 
-select:focus {
+input:focus {
   outline: none;
   border-color: #1a73e8;
   box-shadow: 0 0 0 1px #1a73e8;
+}
+
+.qty {
+  width: 80px;
+  margin-left: 8px;
+}
+
+.over {
+  color: red;
 }
 
 button {

--- a/src/googleSheets.ts
+++ b/src/googleSheets.ts
@@ -34,6 +34,54 @@ export class GoogleSheetsService {
     }));
   }
 
+  private async findUserRow(phoneNumber: string): Promise<{ row: number; balance: number } | null> {
+    const res = await this.sheets.spreadsheets.values.get({
+      spreadsheetId: this.spreadsheetId,
+      range: 'Users!A2:C',
+    });
+    const rows = res.data.values || [];
+    for (let i = 0; i < rows.length; i++) {
+      if (rows[i][0] === phoneNumber) {
+        return { row: i + 2, balance: Number(rows[i][2] || 0) };
+      }
+    }
+    return null;
+  }
+
+  async getUserBalance(phoneNumber: string): Promise<number> {
+    const row = await this.findUserRow(phoneNumber);
+    return row ? row.balance : 0;
+  }
+
+  private async setUserBalance(phoneNumber: string, balance: number): Promise<void> {
+    const row = await this.findUserRow(phoneNumber);
+    if (row) {
+      await this.sheets.spreadsheets.values.update({
+        spreadsheetId: this.spreadsheetId,
+        range: `Users!C${row.row}`,
+        valueInputOption: 'USER_ENTERED',
+        requestBody: { values: [[balance]] },
+      });
+    } else {
+      await this.sheets.spreadsheets.values.append({
+        spreadsheetId: this.spreadsheetId,
+        range: 'Users!A:C',
+        valueInputOption: 'USER_ENTERED',
+        requestBody: { values: [[phoneNumber, '', balance]] },
+      });
+    }
+  }
+
+  async adjustUserBalance(phoneNumber: string, delta: number): Promise<number> {
+    const current = await this.getUserBalance(phoneNumber);
+    const next = current + delta;
+    if (next < 0) {
+      throw new Error('INSUFFICIENT_BALANCE');
+    }
+    await this.setUserBalance(phoneNumber, next);
+    return next;
+  }
+
   async recordPurchase(items: PurchaseItem[], phoneNumber?: string): Promise<void> {
     const timestamp = new Date().toISOString();
     const values = items.map((item) => [timestamp, phoneNumber || '', item.productId, item.quantity]);

--- a/src/index.ts
+++ b/src/index.ts
@@ -24,14 +24,50 @@ app.get("/api/products", async (_req, res) => {
   }
 });
 
+app.get("/api/balance/:phone", async (req, res) => {
+  try {
+    const balance = await sheetsService.getUserBalance(req.params.phone);
+    res.json({ balance });
+  } catch (e) {
+    res.status(500).json({ error: "Failed to load balance" });
+  }
+});
+
 app.post("/api/purchase", async (req, res) => {
   try {
     const items: PurchaseItem[] = req.body.items;
     const phoneNumber: string | undefined = req.body.phoneNumber;
+    const products = await sheetsService.getProducts();
+    const priceMap = new Map(products.map((p) => [p.id, p.price]));
+    const total = items.reduce(
+      (sum, item) => sum + (priceMap.get(item.productId) || 0) * item.quantity,
+      0
+    );
+    let newBalance: number | undefined;
+    if (phoneNumber) {
+      newBalance = await sheetsService.adjustUserBalance(phoneNumber, -total);
+    }
     await sheetsService.recordPurchase(items, phoneNumber);
-    res.json({ status: "success" });
+    res.json({ status: "success", balance: newBalance });
   } catch (e) {
-    res.status(500).json({ error: "Failed to record purchase" });
+    if (e instanceof Error && e.message === "INSUFFICIENT_BALANCE") {
+      res.status(400).json({ error: "Insufficient balance" });
+    } else {
+      res.status(500).json({ error: "Failed to record purchase" });
+    }
+  }
+});
+
+app.post("/api/charge", async (req, res) => {
+  try {
+    const { phoneNumber, amount } = req.body as {
+      phoneNumber: string;
+      amount: number;
+    };
+    const balance = await sheetsService.adjustUserBalance(phoneNumber, amount);
+    res.json({ status: "success", balance });
+  } catch (e) {
+    res.status(500).json({ error: "Failed to charge balance" });
   }
 });
 


### PR DESCRIPTION
## Summary
- Track user balances in `Users` sheet and expose helper methods to adjust them
- Extend API with balance lookup, purchase deduction, and balance charging endpoints
- Update purchase page to require phone number, show current balance, handle multiple items, and block insufficient funds
- Add simple admin form for charging balances

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68a4355aa074832b9c2e89583e887301