### PR TITLE
Add navigation between purchase and charge pages and refresh balance

### DIFF
--- a/pages/charge.tsx
+++ b/pages/charge.tsx
@@ -1,5 +1,6 @@
 import { useState } from 'react';
 import Head from 'next/head';
+import Link from 'next/link';
 
 export default function Charge() {
   const [phone, setPhone] = useState('');
@@ -33,6 +34,7 @@ export default function Charge() {
           <input id="amount" type="number" value={amount} onChange={e=>setAmount(e.target.value)} />
           <button type="submit">Charge</button>
         </form>
+        <Link href="/">Back to Purchase</Link>
       </div>
     </>
   );

--- a/pages/index.tsx
+++ b/pages/index.tsx
@@ -1,5 +1,6 @@
 import { useEffect, useState } from 'react';
 import Head from 'next/head';
+import Link from 'next/link';
 
 interface Product { product_id: string; name: string; price: number; }
 
@@ -30,6 +31,13 @@ export default function Home() {
     const data = await res.json();
     setBalance(data.balance);
   };
+
+  useEffect(() => {
+    loadBalance();
+    const handleFocus = () => loadBalance();
+    window.addEventListener('focus', handleFocus);
+    return () => window.removeEventListener('focus', handleFocus);
+  }, [phone]);
 
   const handleSubmit = async (e: React.FormEvent) => {
     e.preventDefault();
@@ -81,6 +89,7 @@ export default function Home() {
           </div>
           <button type="submit">Purchase</button>
         </form>
+        <Link href="/charge">Money Charge</Link>
       </div>
     </>
   );


### PR DESCRIPTION
## Summary
- add "Money Charge" link on purchase page
- allow navigation back to purchase page from charge
- reload balance when returning to purchase or refocusing window

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68ac313f210c832ba3c53eb57acab675