### PR TITLE
Send charge request and redirect after confirmation

### DIFF
--- a/pages/charge.tsx
+++ b/pages/charge.tsx
@@ -1,21 +1,23 @@
 import { useState } from 'react';
 import Head from 'next/head';
 import Link from 'next/link';
+import { useRouter } from 'next/router';
 
 export default function Charge() {
   const [phone, setPhone] = useState('');
   const [amount, setAmount] = useState('');
+  const router = useRouter();
 
   const submit = async (e: React.FormEvent) => {
     e.preventDefault();
-    const res = await fetch('/api/charge', {
+    const res = await fetch('/api/charge-requests', {
       method: 'POST',
       headers: { 'Content-Type': 'application/json' },
       body: JSON.stringify({ phoneNumber: phone, amount: Number(amount) })
     });
     if (res.ok) {
-      alert('Charged');
-      setAmount('');
+      alert('リクエスト送信完了');
+      await router.push('/');
     } else {
       const err = await res.json();
       alert(err.error || 'Failed to charge');
@@ -32,7 +34,7 @@ export default function Charge() {
           <input id="phone" value={phone} onChange={e=>setPhone(e.target.value)} />
           <label htmlFor="amount">Amount</label>
           <input id="amount" type="number" value={amount} onChange={e=>setAmount(e.target.value)} />
-          <button type="submit">Charge</button>
+          <button type="submit">Charge Request</button>
         </form>
         <Link href="/">Back to Purchase</Link>
       </div>


### PR DESCRIPTION
## Summary
- post charge requests to `/api/charge-requests`
- display confirmation and redirect to purchase page
- retain response error handling

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68ac32b5cf6c832b9e3832662b4fcb5e