### PR TITLE
Add admin web push notifications

### DIFF
--- a/lib/push.ts
+++ b/lib/push.ts
@@ -1,0 +1,17 @@
+import webpush from 'web-push';
+
+const email = process.env.WEB_PUSH_EMAIL || 'example@example.com';
+const publicKey = process.env.WEB_PUSH_PUBLIC_KEY || '';
+const privateKey = process.env.WEB_PUSH_PRIVATE_KEY || '';
+
+if (publicKey && privateKey) {
+  webpush.setVapidDetails(`mailto:${email}`, publicKey, privateKey);
+}
+
+export async function sendPush(subscription: any, payload: any) {
+  try {
+    await webpush.sendNotification(subscription, JSON.stringify(payload));
+  } catch (e) {
+    console.error('push error', e);
+  }
+}

--- a/package.json
+++ b/package.json
@@ -12,7 +12,8 @@
     "googleapis": "^133.0.0",
     "next": "^14.1.0",
     "react": "^18.2.0",
-    "react-dom": "^18.2.0"
+    "react-dom": "^18.2.0",
+    "web-push": "^3.6.0"
   },
   "devDependencies": {
     "@tailwindcss/cli": "^4.1.12",

--- a/pages/_app.tsx
+++ b/pages/_app.tsx
@@ -1,7 +1,35 @@
 import type { AppProps } from 'next/app';
 import Head from 'next/head';
+import { useEffect } from 'react';
 
 export default function MyApp({ Component, pageProps }: AppProps) {
+  useEffect(() => {
+    if (typeof window === 'undefined') return;
+    if (!window.location.pathname.startsWith('/admin')) return;
+    const register = async () => {
+      try {
+        if (!('serviceWorker' in navigator)) return;
+        const perm = await Notification.requestPermission();
+        if (perm !== 'granted') return;
+        const reg = await navigator.serviceWorker.register('/sw.js');
+        let sub = await reg.pushManager.getSubscription();
+        if (!sub) {
+          const vapid = process.env.NEXT_PUBLIC_WEB_PUSH_PUBLIC_KEY;
+          const key = vapid ? urlBase64ToUint8Array(vapid) : undefined;
+          sub = await reg.pushManager.subscribe({ userVisibleOnly: true, applicationServerKey: key });
+        }
+        await fetch('/api/push-subscriptions', {
+          method: 'POST',
+          headers: { 'content-type': 'application/json' },
+          body: JSON.stringify({ adminId: 'admin', subscription: sub })
+        });
+      } catch (e) {
+        console.error(e);
+      }
+    };
+    register();
+  }, []);
+
   return (
     <>
       <Head>
@@ -10,4 +38,15 @@ export default function MyApp({ Component, pageProps }: AppProps) {
       <Component {...pageProps} />
     </>
   );
+}
+
+function urlBase64ToUint8Array(base64String: string) {
+  const padding = '='.repeat((4 - (base64String.length % 4)) % 4);
+  const base64 = (base64String + padding).replace(/-/g, '+').replace(/_/g, '/');
+  const raw = atob(base64);
+  const output = new Uint8Array(raw.length);
+  for (let i = 0; i < raw.length; ++i) {
+    output[i] = raw.charCodeAt(i);
+  }
+  return output;
 }

--- a/pages/api/charge-requests/index.ts
+++ b/pages/api/charge-requests/index.ts
@@ -1,5 +1,6 @@
 import type { NextApiRequest, NextApiResponse } from 'next';
-import { createChargeRequest, listChargeRequests } from '../../../lib/sheet';
+import { createChargeRequest, listChargeRequests, listAdminSubscriptions } from '../../../lib/sheet';
+import { sendPush } from '../../../lib/push';
 
 export default async function handler(req: NextApiRequest, res: NextApiResponse) {
   try {
@@ -8,6 +9,10 @@ export default async function handler(req: NextApiRequest, res: NextApiResponse)
       const amt = Number(amount || 0);
       if (!phoneNumber || !(amt > 0)) return res.status(400).json({ error: 'invalid payload' });
       const id = await createChargeRequest(phoneNumber, amt);
+      const subs = await listAdminSubscriptions();
+      for (const s of subs) {
+        await sendPush(s.subscription, { title: 'Charge Request', body: `${phoneNumber} requested ${amt}` });
+      }
       res.status(200).json({ id });
     } else if (req.method === 'GET') {
       const status = req.query.status === 'approved' ? 'approved' : 'pending';

--- a/pages/api/push-subscriptions.ts
+++ b/pages/api/push-subscriptions.ts
@@ -1,0 +1,19 @@
+import type { NextApiRequest, NextApiResponse } from 'next';
+import { saveAdminSubscription } from '../../lib/sheet';
+
+export default async function handler(req: NextApiRequest, res: NextApiResponse) {
+  if (req.method !== 'POST') {
+    res.status(405).end();
+    return;
+  }
+  try {
+    const { adminId, subscription } = req.body || {};
+    if (!adminId || !subscription) {
+      return res.status(400).json({ error: 'invalid payload' });
+    }
+    await saveAdminSubscription(adminId, subscription);
+    res.status(200).json({ ok: true });
+  } catch (e: any) {
+    res.status(500).json({ error: e.message || String(e) });
+  }
+}

--- a/public/sw.js
+++ b/public/sw.js
@@ -1,0 +1,8 @@
+self.addEventListener('push', event => {
+  const data = event.data ? event.data.json() : {};
+  event.waitUntil(
+    self.registration.showNotification(data.title || 'Notification', {
+      body: data.body || ''
+    })
+  );
+});

--- a/types/shims.d.ts
+++ b/types/shims.d.ts
@@ -28,3 +28,8 @@ declare module 'next/head' {
   const Head: any;
   export default Head;
 }
+
+declare module 'web-push' {
+  const wp: any;
+  export default wp;
+}


### PR DESCRIPTION
## Summary
- register service worker and push subscription on admin pages
- persist admin push subscriptions in sheet and expose API
- send web push notifications to admins when new charge requests are created

## Testing
- `npm test`
- `npm install web-push @types/web-push` *(fails: 403 Forbidden)*

------
https://chatgpt.com/codex/tasks/task_e_68ac379acb2c832ba1605c278ead28ab