### PR TITLE
Import Tailwind CSS globally and add viewport meta

### DIFF
--- a/pages/_app.tsx
+++ b/pages/_app.tsx
@@ -1,3 +1,4 @@
+import '../styles/globals.css';
 import type { AppProps } from 'next/app';
 import Head from 'next/head';
 import { useEffect } from 'react';
@@ -33,7 +34,7 @@ export default function MyApp({ Component, pageProps }: AppProps) {
   return (
     <>
       <Head>
-        <link rel="stylesheet" href="/styles.css" />
+        <meta name="viewport" content="width=device-width, initial-scale=1" />
       </Head>
       <Component {...pageProps} />
     </>

--- a/styles/globals.css
+++ b/styles/globals.css
@@ -1,0 +1,3 @@
+@tailwind base;
+@tailwind components;
+@tailwind utilities;


### PR DESCRIPTION
## Summary
- remove Head link tag for stylesheet
- import Tailwind CSS from `styles/globals.css`
- add responsive viewport meta tag

## Testing
- `npm test`
- `npm run build` *(fails: No prebuild or local build of @parcel/watcher found)*

------
https://chatgpt.com/codex/tasks/task_e_68ac4f3a4b98832bae160e22c96bb6b8