### PR TITLE
Style admin pages with Tailwind layout

### DIFF
--- a/components/AdminLayout.tsx
+++ b/components/AdminLayout.tsx
@@ -1,0 +1,35 @@
+import Head from 'next/head';
+import Link from 'next/link';
+import { ReactNode } from 'react';
+
+interface Props {
+  title: string;
+  children: ReactNode;
+}
+
+export default function AdminLayout({ title, children }: Props) {
+  return (
+    <>
+      <Head><title>{title}</title></Head>
+      <div className="min-h-screen bg-gray-50">
+        <header className="bg-blue-600 text-white p-4">
+          <h1 className="text-xl font-bold">Admin Panel</h1>
+        </header>
+        <nav className="bg-white shadow p-4">
+          <ul className="flex space-x-4">
+            <li>
+              <Link href="/admin/requests" className="text-blue-600 hover:underline">Requests</Link>
+            </li>
+            <li>
+              <Link href="/admin/products" className="text-blue-600 hover:underline">Products</Link>
+            </li>
+            <li>
+              <Link href="/admin/sales" className="text-blue-600 hover:underline">Sales</Link>
+            </li>
+          </ul>
+        </nav>
+        <main className="p-4">{children}</main>
+      </div>
+    </>
+  );
+}

--- a/pages/admin/index.tsx
+++ b/pages/admin/index.tsx
@@ -1,16 +1,15 @@
-import Head from 'next/head';
 import Link from 'next/link';
+import AdminLayout from '../../components/AdminLayout';
 
 export default function AdminIndex() {
   return (
-    <>
-      <Head><title>Admin</title></Head>
-      <h1>Admin</h1>
-      <ul>
-        <li><Link href="/admin/requests">Charge Requests</Link></li>
-        <li><Link href="/admin/products">Product Management</Link></li>
-        <li><Link href="/admin/sales">Sales Dashboard</Link></li>
+    <AdminLayout title="Admin">
+      <h1 className="text-2xl font-bold mb-4">Admin</h1>
+      <ul className="list-disc pl-5 space-y-2">
+        <li><Link href="/admin/requests" className="text-blue-600 hover:underline">Charge Requests</Link></li>
+        <li><Link href="/admin/products" className="text-blue-600 hover:underline">Product Management</Link></li>
+        <li><Link href="/admin/sales" className="text-blue-600 hover:underline">Sales Dashboard</Link></li>
       </ul>
-    </>
+    </AdminLayout>
   );
 }

--- a/pages/admin/products.tsx
+++ b/pages/admin/products.tsx
@@ -1,5 +1,5 @@
 import { useEffect, useState } from 'react';
-import Head from 'next/head';
+import AdminLayout from '../../components/AdminLayout';
 
 interface Product { product_id: string; name: string; price: number; }
 
@@ -52,10 +52,9 @@ export default function ProductsPage() {
   };
 
   return (
-    <>
-      <Head><title>Product Management</title></Head>
+    <AdminLayout title="Product Management">
       <div className="mx-auto mt-4 max-w-md p-6 bg-white rounded shadow">
-        <h1 className="text-xl font-bold mb-4">Product Management</h1>
+        <h1 className="text-2xl font-bold mb-4">Product Management</h1>
         <form onSubmit={submit} className="space-y-2 mb-4">
           <input
             placeholder="Product ID"
@@ -78,34 +77,34 @@ export default function ProductsPage() {
             className="w-full p-2 border border-gray-300 rounded focus:outline-none focus:ring-1 focus:ring-blue-500 focus:border-blue-500"
           />
           <div className="space-x-2">
-            <button type="submit" className="px-4 py-2 bg-blue-600 text-white rounded hover:bg-blue-700">{editing ? 'Update' : 'Add'}</button>
-            {editing && <button type="button" onClick={cancel} className="px-4 py-2 bg-gray-300 text-gray-800 rounded hover:bg-gray-400">Cancel</button>}
+            <button type="submit" className="btn btn-primary">{editing ? 'Update' : 'Add'}</button>
+            {editing && <button type="button" onClick={cancel} className="btn btn-secondary">Cancel</button>}
           </div>
         </form>
-        <table className="w-full border border-collapse">
-          <thead>
-            <tr className="bg-gray-100">
-              <th className="border p-2">ID</th>
-              <th className="border p-2">Name</th>
-              <th className="border p-2">Price</th>
-              <th className="border p-2"></th>
+        <table className="table-auto w-full border border-collapse text-left">
+          <thead className="bg-gray-100">
+            <tr>
+              <th className="border px-4 py-2">ID</th>
+              <th className="border px-4 py-2">Name</th>
+              <th className="border px-4 py-2">Price</th>
+              <th className="border px-4 py-2"></th>
             </tr>
           </thead>
           <tbody>
             {items.map(p => (
               <tr key={p.product_id}>
-                <td className="border p-2">{p.product_id}</td>
-                <td className="border p-2">{p.name}</td>
-                <td className="border p-2">{p.price}</td>
-                <td className="border p-2 space-x-2">
-                  <button onClick={() => edit(p)} className="px-2 py-1 bg-blue-600 text-white rounded hover:bg-blue-700">Edit</button>
-                  <button onClick={() => del(p.product_id)} className="px-2 py-1 bg-red-600 text-white rounded hover:bg-red-700">Delete</button>
+                <td className="border px-4 py-2">{p.product_id}</td>
+                <td className="border px-4 py-2">{p.name}</td>
+                <td className="border px-4 py-2">{p.price}</td>
+                <td className="border px-4 py-2 space-x-2">
+                  <button onClick={() => edit(p)} className="btn btn-secondary btn-sm">Edit</button>
+                  <button onClick={() => del(p.product_id)} className="btn btn-secondary btn-sm">Delete</button>
                 </td>
               </tr>
             ))}
           </tbody>
         </table>
       </div>
-    </>
+    </AdminLayout>
   );
 }

--- a/pages/admin/requests.tsx
+++ b/pages/admin/requests.tsx
@@ -1,5 +1,5 @@
 import { useEffect, useState } from 'react';
-import Head from 'next/head';
+import AdminLayout from '../../components/AdminLayout';
 
 interface Request {
   id: string;
@@ -29,30 +29,36 @@ export default function RequestsPage() {
   };
 
   return (
-    <>
-      <Head><title>Charge Requests</title></Head>
-      <h1>Charge Requests</h1>
-      <div>
-        <button disabled={tab === 'pending'} onClick={() => setTab('pending')}>pending</button>
-        <button disabled={tab === 'approved'} onClick={() => setTab('approved')}>approved</button>
+    <AdminLayout title="Charge Requests">
+      <h1 className="text-2xl font-bold mb-4">Charge Requests</h1>
+      <div className="space-x-2 mb-4">
+        <button className="btn btn-secondary" disabled={tab === 'pending'} onClick={() => setTab('pending')}>pending</button>
+        <button className="btn btn-secondary" disabled={tab === 'approved'} onClick={() => setTab('approved')}>approved</button>
       </div>
-      <table border={1}>
-        <thead>
-          <tr><th>ID</th><th>Phone</th><th>Amount</th><th>Requested</th><th>Approved</th><th></th></tr>
+      <table className="table-auto w-full border border-collapse text-left">
+        <thead className="bg-gray-100">
+          <tr>
+            <th className="border px-4 py-2">ID</th>
+            <th className="border px-4 py-2">Phone</th>
+            <th className="border px-4 py-2">Amount</th>
+            <th className="border px-4 py-2">Requested</th>
+            <th className="border px-4 py-2">Approved</th>
+            <th className="border px-4 py-2"></th>
+          </tr>
         </thead>
         <tbody>
           {items.map(r => (
             <tr key={r.id}>
-              <td>{r.id}</td>
-              <td>{r.phone}</td>
-              <td>{r.amount}</td>
-              <td>{r.requested_at}</td>
-              <td>{r.approved_at}</td>
-              <td>{!r.approved && <button onClick={() => approve(r.id)}>Approve</button>}</td>
+              <td className="border px-4 py-2">{r.id}</td>
+              <td className="border px-4 py-2">{r.phone}</td>
+              <td className="border px-4 py-2">{r.amount}</td>
+              <td className="border px-4 py-2">{r.requested_at}</td>
+              <td className="border px-4 py-2">{r.approved_at}</td>
+              <td className="border px-4 py-2">{!r.approved && <button className="btn btn-secondary btn-sm" onClick={() => approve(r.id)}>Approve</button>}</td>
             </tr>
           ))}
         </tbody>
       </table>
-    </>
+    </AdminLayout>
   );
 }

--- a/pages/admin/sales.tsx
+++ b/pages/admin/sales.tsx
@@ -1,7 +1,7 @@
 import { useEffect, useState } from 'react';
-import Head from 'next/head';
+import AdminLayout from '../../components/AdminLayout';
 
-export default function Admin() {
+export default function SalesPage() {
   const [data, setData] = useState<Record<string, number>>({});
 
   useEffect(() => {
@@ -9,17 +9,24 @@ export default function Admin() {
   }, []);
 
   return (
-    <>
-      <Head><title>Sales Dashboard</title></Head>
-      <h1>Sales Dashboard</h1>
-      <table border={1}>
-        <thead><tr><th>Product ID</th><th>Quantity</th></tr></thead>
+    <AdminLayout title="Sales Dashboard">
+      <h1 className="text-2xl font-bold mb-4">Sales Dashboard</h1>
+      <table className="table-auto w-full border border-collapse text-left">
+        <thead className="bg-gray-100">
+          <tr>
+            <th className="border px-4 py-2">Product ID</th>
+            <th className="border px-4 py-2">Quantity</th>
+          </tr>
+        </thead>
         <tbody>
           {Object.entries(data).map(([id, qty]) => (
-            <tr key={id}><td>{id}</td><td>{qty}</td></tr>
+            <tr key={id}>
+              <td className="border px-4 py-2">{id}</td>
+              <td className="border px-4 py-2">{qty}</td>
+            </tr>
           ))}
         </tbody>
       </table>
-    </>
+    </AdminLayout>
   );
 }


### PR DESCRIPTION
## Summary
- add shared `AdminLayout` with header and navigation
- style admin pages using Tailwind utilities and remove HTML border attributes

## Testing
- `npm test` (fails: Cannot find type definition file for 'node', 'prop-types', 'react', 'react-dom')

------
https://chatgpt.com/codex/tasks/task_e_68ac55641248832b9849044100e64c76