### PR TITLE
chore: configure Tailwind PostCSS plugin

### DIFF
--- a/package.json
+++ b/package.json
@@ -18,6 +18,7 @@
   "devDependencies": {
     "@tailwindcss/cli": "^4.1.12",
     "@tailwindcss/forms": "^0.5.10",
+    "@tailwindcss/postcss": "^4.1.0",
     "@types/node": "^18.19.123",
     "@types/react": "^18.2.37",
     "@types/react-dom": "^18.2.15",

--- a/postcss.config.js
+++ b/postcss.config.js
@@ -1,5 +1,5 @@
 export default {
   plugins: {
-    tailwindcss: {},
+    '@tailwindcss/postcss': {},
   },
 };


### PR DESCRIPTION
## Summary
- add `@tailwindcss/postcss` dev dependency
- configure PostCSS to use the Tailwind PostCSS plugin

## Testing
- `npm test`
- `npm run build` *(fails: Cannot find module '@tailwindcss/postcss')*


------
https://chatgpt.com/codex/tasks/task_e_68ac70bf2ed0832bbe66f367d3cc6019