### PR TITLE
Add Tailwind CSS forms plugin

### DIFF
--- a/tailwind.config.ts
+++ b/tailwind.config.ts
@@ -2,10 +2,10 @@ const config = {
   content: [
     './pages/**/*.{ts,tsx}',
     './components/**/*.{ts,tsx}',
-    './public/index.html'
+    './public/index.html',
   ],
   theme: {},
-  plugins: [],
+  plugins: [require('@tailwindcss/forms')],
 };
 
 export default config;


### PR DESCRIPTION
## Summary
- enable `@tailwindcss/forms` plugin in Tailwind configuration

## Testing
- `npm test`
- `npm run build` *(fails: Cannot find module '@tailwindcss/postcss')*


------
https://chatgpt.com/codex/tasks/task_e_68ac71e43868832b9144d4077802f3f4