### PR TITLE
refactor ui with tailwind design tokens

### DIFF
--- a/components/AdminLayout.tsx
+++ b/components/AdminLayout.tsx
@@ -1,6 +1,6 @@
-import Head from 'next/head';
-import Link from 'next/link';
-import { ReactNode } from 'react';
+import Head from "next/head";
+import Link from "next/link";
+import { ReactNode } from "react";
 
 interface Props {
   title: string;
@@ -10,25 +10,40 @@ interface Props {
 export default function AdminLayout({ title, children }: Props) {
   return (
     <>
-      <Head><title>{title}</title></Head>
-      <div className="min-h-screen bg-gray-50">
-        <header className="bg-blue-600 text-white p-4">
-          <h1 className="text-xl font-bold">Admin Panel</h1>
+      <Head>
+        <title>{title}</title>
+      </Head>
+      <div className="min-h-screen bg-slate-50 dark:bg-slate-900 text-slate-900 dark:text-slate-100">
+        <header className="border-b border-slate-200 dark:border-slate-700 bg-white dark:bg-slate-900 shadow-lg shadow-black/5">
+          <div className="mx-auto max-w-xl md:max-w-3xl lg:max-w-5xl p-6 sm:p-8">
+            <h1 className="text-2xl font-semibold tracking-tight">Admin Panel</h1>
+          </div>
         </header>
-        <nav className="bg-white shadow p-4">
-          <ul className="flex space-x-4">
-            <li>
-              <Link href="/admin/requests" className="text-blue-600 hover:underline">Requests</Link>
-            </li>
-            <li>
-              <Link href="/admin/products" className="text-blue-600 hover:underline">Products</Link>
-            </li>
-            <li>
-              <Link href="/admin/sales" className="text-blue-600 hover:underline">Sales</Link>
-            </li>
-          </ul>
+        <nav className="border-b border-slate-200 dark:border-slate-700 bg-slate-50 dark:bg-slate-800">
+          <div className="mx-auto max-w-xl md:max-w-3xl lg:max-w-5xl p-6 sm:p-8 flex gap-6">
+            <Link
+              href="/admin/requests"
+              className="inline-flex h-11 items-center justify-center rounded-xl px-6 text-blue-600 hover:bg-blue-50 dark:hover:bg-slate-700 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-blue-600 focus-visible:ring-offset-2 focus-visible:ring-offset-slate-50 dark:focus-visible:ring-offset-slate-800"
+            >
+              Requests
+            </Link>
+            <Link
+              href="/admin/products"
+              className="inline-flex h-11 items-center justify-center rounded-xl px-6 text-blue-600 hover:bg-blue-50 dark:hover:bg-slate-700 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-blue-600 focus-visible:ring-offset-2 focus-visible:ring-offset-slate-50 dark:focus-visible:ring-offset-slate-800"
+            >
+              Products
+            </Link>
+            <Link
+              href="/admin/sales"
+              className="inline-flex h-11 items-center justify-center rounded-xl px-6 text-blue-600 hover:bg-blue-50 dark:hover:bg-slate-700 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-blue-600 focus-visible:ring-offset-2 focus-visible:ring-offset-slate-50 dark:focus-visible:ring-offset-slate-800"
+            >
+              Sales
+            </Link>
+          </div>
         </nav>
-        <main className="p-4">{children}</main>
+        <main className="mx-auto max-w-xl md:max-w-3xl lg:max-w-5xl p-6 sm:p-8 space-y-8">
+          {children}
+        </main>
       </div>
     </>
   );

--- a/components/Toast.tsx
+++ b/components/Toast.tsx
@@ -1,0 +1,22 @@
+import { ReactNode } from "react";
+
+interface ToastProps {
+  type: "success" | "error";
+  message: ReactNode;
+}
+
+export default function Toast({ type, message }: ToastProps) {
+  return (
+    <div
+      role="status"
+      aria-live="polite"
+      className={`fixed bottom-6 right-6 rounded-2xl p-4 shadow-lg shadow-black/5 border ${
+        type === "success"
+          ? "border-emerald-600 text-emerald-600 bg-white dark:bg-slate-900"
+          : "border-rose-600 text-rose-600 bg-white dark:bg-slate-900"
+      }`}
+    >
+      {message}
+    </div>
+  );
+}

--- a/pages/admin/index.tsx
+++ b/pages/admin/index.tsx
@@ -1,15 +1,47 @@
-import Link from 'next/link';
-import AdminLayout from '../../components/AdminLayout';
+import Link from "next/link";
+import AdminLayout from "../../components/AdminLayout";
 
 export default function AdminIndex() {
   return (
     <AdminLayout title="Admin">
-      <h1 className="text-2xl font-bold mb-4">Admin</h1>
-      <ul className="list-disc pl-5 space-y-2">
-        <li><Link href="/admin/requests" className="text-blue-600 hover:underline">Charge Requests</Link></li>
-        <li><Link href="/admin/products" className="text-blue-600 hover:underline">Product Management</Link></li>
-        <li><Link href="/admin/sales" className="text-blue-600 hover:underline">Sales Dashboard</Link></li>
-      </ul>
+      <section
+        className="rounded-2xl border border-slate-200 dark:border-slate-700 bg-white dark:bg-slate-900 shadow-lg shadow-black/5 divide-y divide-slate-200 dark:divide-slate-700"
+        aria-labelledby="admin-heading"
+      >
+        <header className="p-6">
+          <h1 id="admin-heading" className="text-3xl font-semibold tracking-tight text-slate-900 dark:text-slate-100">
+            Admin
+          </h1>
+        </header>
+        <div className="p-6">
+          <ul className="space-y-2 text-sm text-slate-500">
+            <li>
+              <Link
+                href="/admin/requests"
+                className="inline-flex h-11 items-center justify-start rounded-xl px-6 text-blue-600 hover:bg-blue-50 dark:hover:bg-slate-800 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-blue-600 focus-visible:ring-offset-2 focus-visible:ring-offset-white dark:focus-visible:ring-offset-slate-900"
+              >
+                Charge Requests
+              </Link>
+            </li>
+            <li>
+              <Link
+                href="/admin/products"
+                className="inline-flex h-11 items-center justify-start rounded-xl px-6 text-blue-600 hover:bg-blue-50 dark:hover:bg-slate-800 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-blue-600 focus-visible:ring-offset-2 focus-visible:ring-offset-white dark:focus-visible:ring-offset-slate-900"
+              >
+                Product Management
+              </Link>
+            </li>
+            <li>
+              <Link
+                href="/admin/sales"
+                className="inline-flex h-11 items-center justify-start rounded-xl px-6 text-blue-600 hover:bg-blue-50 dark:hover:bg-slate-800 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-blue-600 focus-visible:ring-offset-2 focus-visible:ring-offset-white dark:focus-visible:ring-offset-slate-900"
+              >
+                Sales Dashboard
+              </Link>
+            </li>
+          </ul>
+        </div>
+      </section>
     </AdminLayout>
   );
 }

--- a/pages/admin/products.tsx
+++ b/pages/admin/products.tsx
@@ -1,31 +1,37 @@
-import { useEffect, useState } from 'react';
-import AdminLayout from '../../components/AdminLayout';
+import { useEffect, useState } from "react";
+import AdminLayout from "../../components/AdminLayout";
 
-interface Product { product_id: string; name: string; price: number; }
+interface Product {
+  product_id: string;
+  name: string;
+  price: number;
+}
 
 export default function ProductsPage() {
   const [items, setItems] = useState<Product[]>([]);
-  const [form, setForm] = useState({ product_id: '', name: '', price: '' });
+  const [form, setForm] = useState({ product_id: "", name: "", price: "" });
   const [editing, setEditing] = useState<string | null>(null);
 
   const load = async () => {
-    const res = await fetch('/api/products');
+    const res = await fetch("/api/products");
     const data = await res.json();
     setItems(data);
   };
-  useEffect(() => { load(); }, []);
+  useEffect(() => {
+    load();
+  }, []);
 
   const submit = async (e: React.FormEvent) => {
     e.preventDefault();
     const payload = { product_id: form.product_id, name: form.name, price: Number(form.price) };
-    const method = editing ? 'PUT' : 'POST';
-    const res = await fetch('/api/products', {
+    const method = editing ? "PUT" : "POST";
+    const res = await fetch("/api/products", {
       method,
-      headers: { 'Content-Type': 'application/json' },
+      headers: { "Content-Type": "application/json" },
       body: JSON.stringify(payload)
     });
     if (res.ok) {
-      setForm({ product_id: '', name: '', price: '' });
+      setForm({ product_id: "", name: "", price: "" });
       setEditing(null);
       load();
     }
@@ -37,10 +43,10 @@ export default function ProductsPage() {
   };
 
   const del = async (id: string) => {
-    if (!window.confirm('Delete?')) return;
-    const res = await fetch('/api/products', {
-      method: 'DELETE',
-      headers: { 'Content-Type': 'application/json' },
+    if (!window.confirm("Delete?")) return;
+    const res = await fetch("/api/products", {
+      method: "DELETE",
+      headers: { "Content-Type": "application/json" },
       body: JSON.stringify({ product_id: id })
     });
     if (res.ok) load();
@@ -48,63 +54,118 @@ export default function ProductsPage() {
 
   const cancel = () => {
     setEditing(null);
-    setForm({ product_id: '', name: '', price: '' });
+    setForm({ product_id: "", name: "", price: "" });
   };
 
   return (
     <AdminLayout title="Product Management">
-      <div className="mx-auto mt-4 max-w-md p-6 bg-white rounded shadow">
-        <h1 className="text-2xl font-bold mb-4">Product Management</h1>
-        <form onSubmit={submit} className="space-y-2 mb-4">
-          <input
-            placeholder="Product ID"
-            value={form.product_id}
-            onChange={e=>setForm({ ...form, product_id: e.target.value })}
-            disabled={!!editing}
-            className="w-full p-2 border border-gray-300 rounded focus:outline-none focus:ring-1 focus:ring-blue-500 focus:border-blue-500"
-          />
-          <input
-            placeholder="Name"
-            value={form.name}
-            onChange={e=>setForm({ ...form, name: e.target.value })}
-            className="w-full p-2 border border-gray-300 rounded focus:outline-none focus:ring-1 focus:ring-blue-500 focus:border-blue-500"
-          />
-          <input
-            placeholder="Price"
-            type="number"
-            value={form.price}
-            onChange={e=>setForm({ ...form, price: e.target.value })}
-            className="w-full p-2 border border-gray-300 rounded focus:outline-none focus:ring-1 focus:ring-blue-500 focus:border-blue-500"
-          />
-          <div className="space-x-2">
-            <button type="submit" className="btn btn-primary">{editing ? 'Update' : 'Add'}</button>
-            {editing && <button type="button" onClick={cancel} className="btn btn-secondary">Cancel</button>}
+      <section
+        className="rounded-2xl border border-slate-200 dark:border-slate-700 bg-white dark:bg-slate-900 shadow-lg shadow-black/5 divide-y divide-slate-200 dark:divide-slate-700"
+        aria-labelledby="products-heading"
+      >
+        <header className="p-6">
+          <h1 id="products-heading" className="text-3xl font-semibold tracking-tight text-slate-900 dark:text-slate-100">
+            Product Management
+          </h1>
+        </header>
+        <div className="p-6 space-y-6 text-sm text-slate-500">
+          <form onSubmit={submit} className="space-y-6">
+            <div className="space-y-2">
+              <label htmlFor="product_id" className="flex items-baseline gap-1 text-slate-900 dark:text-slate-100">
+                Product ID<span aria-hidden="true" className="text-rose-600">*</span>
+              </label>
+              <input
+                id="product_id"
+                value={form.product_id}
+                onChange={e => setForm({ ...form, product_id: e.target.value })}
+                required
+                aria-required="true"
+                disabled={!!editing}
+                className="h-11 w-full rounded-xl border border-slate-300 dark:border-slate-600 bg-white dark:bg-slate-900 px-4 font-mono tabular-nums text-slate-900 dark:text-slate-100 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-blue-600 focus-visible:ring-offset-2 focus-visible:ring-offset-white dark:focus-visible:ring-offset-slate-900"
+              />
+            </div>
+            <div className="space-y-2">
+              <label htmlFor="name" className="flex items-baseline gap-1 text-slate-900 dark:text-slate-100">
+                Name<span aria-hidden="true" className="text-rose-600">*</span>
+              </label>
+              <input
+                id="name"
+                value={form.name}
+                onChange={e => setForm({ ...form, name: e.target.value })}
+                required
+                aria-required="true"
+                className="h-11 w-full rounded-xl border border-slate-300 dark:border-slate-600 bg-white dark:bg-slate-900 px-4 text-slate-900 dark:text-slate-100 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-blue-600 focus-visible:ring-offset-2 focus-visible:ring-offset-white dark:focus-visible:ring-offset-slate-900"
+              />
+            </div>
+            <div className="space-y-2">
+              <label htmlFor="price" className="flex items-baseline gap-1 text-slate-900 dark:text-slate-100">
+                Price<span aria-hidden="true" className="text-rose-600">*</span>
+              </label>
+              <input
+                id="price"
+                type="number"
+                value={form.price}
+                onChange={e => setForm({ ...form, price: e.target.value })}
+                required
+                aria-required="true"
+                className="h-11 w-full rounded-xl border border-slate-300 dark:border-slate-600 bg-white dark:bg-slate-900 px-4 font-mono tabular-nums text-slate-900 dark:text-slate-100 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-blue-600 focus-visible:ring-offset-2 focus-visible:ring-offset-white dark:focus-visible:ring-offset-slate-900"
+              />
+            </div>
+            <div className="flex gap-2 pt-6">
+              <button
+                type="submit"
+                className="h-11 min-w-[44px] rounded-xl bg-blue-600 px-6 text-white hover:bg-blue-700 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-blue-600 focus-visible:ring-offset-2 focus-visible:ring-offset-white dark:focus-visible:ring-offset-slate-900"
+              >
+                {editing ? "Update" : "Add"}
+              </button>
+              {editing && (
+                <button
+                  type="button"
+                  onClick={cancel}
+                  className="h-11 min-w-[44px] rounded-xl border border-blue-600 text-blue-600 px-6 hover:bg-blue-50 dark:hover:bg-slate-800 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-blue-600 focus-visible:ring-offset-2 focus-visible:ring-offset-white dark:focus-visible:ring-offset-slate-900"
+                >
+                  Cancel
+                </button>
+              )}
+            </div>
+          </form>
+          <div className="overflow-x-auto">
+            <table className="w-full border border-slate-200 dark:border-slate-700 text-left text-slate-900 dark:text-slate-100 font-mono tabular-nums">
+              <thead className="bg-slate-50 dark:bg-slate-800">
+                <tr>
+                  <th className="border border-slate-200 dark:border-slate-700 px-4 py-2">ID</th>
+                  <th className="border border-slate-200 dark:border-slate-700 px-4 py-2">Name</th>
+                  <th className="border border-slate-200 dark:border-slate-700 px-4 py-2">Price</th>
+                  <th className="border border-slate-200 dark:border-slate-700 px-4 py-2"></th>
+                </tr>
+              </thead>
+              <tbody>
+                {items.map(p => (
+                  <tr key={p.product_id} className="text-slate-900 dark:text-slate-100">
+                    <td className="border border-slate-200 dark:border-slate-700 px-4 py-2">{p.product_id}</td>
+                    <td className="border border-slate-200 dark:border-slate-700 px-4 py-2">{p.name}</td>
+                    <td className="border border-slate-200 dark:border-slate-700 px-4 py-2">¥{p.price}</td>
+                    <td className="border border-slate-200 dark:border-slate-700 px-4 py-2 space-x-2">
+                      <button
+                        onClick={() => edit(p)}
+                        className="h-11 min-w-[44px] rounded-xl border border-blue-600 text-blue-600 px-6 hover:bg-blue-50 dark:hover:bg-slate-800 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-blue-600 focus-visible:ring-offset-2 focus-visible:ring-offset-white dark:focus-visible:ring-offset-slate-900"
+                      >
+                        Edit
+                      </button>
+                      <button
+                        onClick={() => del(p.product_id)}
+                        className="h-11 min-w-[44px] rounded-xl border border-rose-600 text-rose-600 px-6 hover:bg-rose-50 dark:hover:bg-slate-800 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-rose-600 focus-visible:ring-offset-2 focus-visible:ring-offset-white dark:focus-visible:ring-offset-slate-900"
+                      >
+                        Delete
+                      </button>
+                    </td>
+                  </tr>
+                ))}
+              </tbody>
+            </table>
           </div>
-        </form>
-        <table className="table-auto w-full border border-collapse text-left">
-          <thead className="bg-gray-100">
-            <tr>
-              <th className="border px-4 py-2">ID</th>
-              <th className="border px-4 py-2">Name</th>
-              <th className="border px-4 py-2">Price</th>
-              <th className="border px-4 py-2"></th>
-            </tr>
-          </thead>
-          <tbody>
-            {items.map(p => (
-              <tr key={p.product_id}>
-                <td className="border px-4 py-2">{p.product_id}</td>
-                <td className="border px-4 py-2">{p.name}</td>
-                <td className="border px-4 py-2">{p.price}</td>
-                <td className="border px-4 py-2 space-x-2">
-                  <button onClick={() => edit(p)} className="btn btn-secondary btn-sm">Edit</button>
-                  <button onClick={() => del(p.product_id)} className="btn btn-secondary btn-sm">Delete</button>
-                </td>
-              </tr>
-            ))}
-          </tbody>
-        </table>
-      </div>
+        </div>
+      </section>
     </AdminLayout>
   );
 }

--- a/pages/admin/requests.tsx
+++ b/pages/admin/requests.tsx
@@ -1,5 +1,5 @@
-import { useEffect, useState } from 'react';
-import AdminLayout from '../../components/AdminLayout';
+import { useEffect, useState } from "react";
+import AdminLayout from "../../components/AdminLayout";
 
 interface Request {
   id: string;
@@ -11,54 +11,90 @@ interface Request {
 }
 
 export default function RequestsPage() {
-  const [tab, setTab] = useState<'pending' | 'approved'>('pending');
+  const [tab, setTab] = useState<"pending" | "approved">("pending");
   const [items, setItems] = useState<Request[]>([]);
 
-  const load = async (status: 'pending' | 'approved') => {
+  const load = async (status: "pending" | "approved") => {
     const res = await fetch(`/api/charge-requests?status=${status}`);
     const data = await res.json();
     setItems(data);
   };
 
-  useEffect(() => { load(tab); }, [tab]);
+  useEffect(() => {
+    load(tab);
+  }, [tab]);
 
   const approve = async (id: string) => {
-    if (!window.confirm('Are you confirm this request?')) return;
-    const res = await fetch(`/api/charge-requests/${id}/approve`, { method: 'POST' });
+    if (!window.confirm("Are you confirm this request?")) return;
+    const res = await fetch(`/api/charge-requests/${id}/approve`, { method: "POST" });
     if (res.ok) load(tab);
   };
 
   return (
     <AdminLayout title="Charge Requests">
-      <h1 className="text-2xl font-bold mb-4">Charge Requests</h1>
-      <div className="space-x-2 mb-4">
-        <button className="btn btn-secondary" disabled={tab === 'pending'} onClick={() => setTab('pending')}>pending</button>
-        <button className="btn btn-secondary" disabled={tab === 'approved'} onClick={() => setTab('approved')}>approved</button>
-      </div>
-      <table className="table-auto w-full border border-collapse text-left">
-        <thead className="bg-gray-100">
-          <tr>
-            <th className="border px-4 py-2">ID</th>
-            <th className="border px-4 py-2">Phone</th>
-            <th className="border px-4 py-2">Amount</th>
-            <th className="border px-4 py-2">Requested</th>
-            <th className="border px-4 py-2">Approved</th>
-            <th className="border px-4 py-2"></th>
-          </tr>
-        </thead>
-        <tbody>
-          {items.map(r => (
-            <tr key={r.id}>
-              <td className="border px-4 py-2">{r.id}</td>
-              <td className="border px-4 py-2">{r.phone}</td>
-              <td className="border px-4 py-2">{r.amount}</td>
-              <td className="border px-4 py-2">{r.requested_at}</td>
-              <td className="border px-4 py-2">{r.approved_at}</td>
-              <td className="border px-4 py-2">{!r.approved && <button className="btn btn-secondary btn-sm" onClick={() => approve(r.id)}>Approve</button>}</td>
-            </tr>
-          ))}
-        </tbody>
-      </table>
+      <section
+        className="rounded-2xl border border-slate-200 dark:border-slate-700 bg-white dark:bg-slate-900 shadow-lg shadow-black/5 divide-y divide-slate-200 dark:divide-slate-700"
+        aria-labelledby="requests-heading"
+      >
+        <header className="p-6">
+          <h1 id="requests-heading" className="text-3xl font-semibold tracking-tight text-slate-900 dark:text-slate-100">
+            Charge Requests
+          </h1>
+        </header>
+        <div className="p-6 space-y-6 text-sm text-slate-500">
+          <div className="flex gap-4">
+            <button
+              className="h-11 min-w-[44px] rounded-xl border border-blue-600 text-blue-600 px-6 hover:bg-blue-50 dark:hover:bg-slate-800 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-blue-600 focus-visible:ring-offset-2 focus-visible:ring-offset-white dark:focus-visible:ring-offset-slate-900 disabled:opacity-50"
+              disabled={tab === "pending"}
+              onClick={() => setTab("pending")}
+            >
+              pending
+            </button>
+            <button
+              className="h-11 min-w-[44px] rounded-xl border border-blue-600 text-blue-600 px-6 hover:bg-blue-50 dark:hover:bg-slate-800 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-blue-600 focus-visible:ring-offset-2 focus-visible:ring-offset-white dark:focus-visible:ring-offset-slate-900 disabled:opacity-50"
+              disabled={tab === "approved"}
+              onClick={() => setTab("approved")}
+            >
+              approved
+            </button>
+          </div>
+          <div className="overflow-x-auto">
+            <table className="w-full border border-slate-200 dark:border-slate-700 text-left text-slate-900 dark:text-slate-100 font-mono tabular-nums">
+              <thead className="bg-slate-50 dark:bg-slate-800 text-slate-900 dark:text-slate-100">
+                <tr>
+                  <th className="border border-slate-200 dark:border-slate-700 px-4 py-2">ID</th>
+                  <th className="border border-slate-200 dark:border-slate-700 px-4 py-2">Phone</th>
+                  <th className="border border-slate-200 dark:border-slate-700 px-4 py-2">Amount</th>
+                  <th className="border border-slate-200 dark:border-slate-700 px-4 py-2">Requested</th>
+                  <th className="border border-slate-200 dark:border-slate-700 px-4 py-2">Approved</th>
+                  <th className="border border-slate-200 dark:border-slate-700 px-4 py-2"></th>
+                </tr>
+              </thead>
+              <tbody>
+                {items.map(r => (
+                  <tr key={r.id} className="text-slate-900 dark:text-slate-100">
+                    <td className="border border-slate-200 dark:border-slate-700 px-4 py-2">{r.id}</td>
+                    <td className="border border-slate-200 dark:border-slate-700 px-4 py-2">{r.phone}</td>
+                    <td className="border border-slate-200 dark:border-slate-700 px-4 py-2">¥{r.amount}</td>
+                    <td className="border border-slate-200 dark:border-slate-700 px-4 py-2">{r.requested_at}</td>
+                    <td className="border border-slate-200 dark:border-slate-700 px-4 py-2">{r.approved_at}</td>
+                    <td className="border border-slate-200 dark:border-slate-700 px-4 py-2">
+                      {!r.approved && (
+                        <button
+                          onClick={() => approve(r.id)}
+                          className="h-11 min-w-[44px] rounded-xl bg-blue-600 px-6 text-white hover:bg-blue-700 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-blue-600 focus-visible:ring-offset-2 focus-visible:ring-offset-white dark:focus-visible:ring-offset-slate-900"
+                        >
+                          Approve
+                        </button>
+                      )}
+                    </td>
+                  </tr>
+                ))}
+              </tbody>
+            </table>
+          </div>
+        </div>
+      </section>
     </AdminLayout>
   );
 }

--- a/pages/admin/sales.tsx
+++ b/pages/admin/sales.tsx
@@ -1,32 +1,45 @@
-import { useEffect, useState } from 'react';
-import AdminLayout from '../../components/AdminLayout';
+import { useEffect, useState } from "react";
+import AdminLayout from "../../components/AdminLayout";
 
 export default function SalesPage() {
   const [data, setData] = useState<Record<string, number>>({});
 
   useEffect(() => {
-    fetch('/api/sales').then(r => r.json()).then(setData);
+    fetch("/api/sales").then(r => r.json()).then(setData);
   }, []);
 
   return (
     <AdminLayout title="Sales Dashboard">
-      <h1 className="text-2xl font-bold mb-4">Sales Dashboard</h1>
-      <table className="table-auto w-full border border-collapse text-left">
-        <thead className="bg-gray-100">
-          <tr>
-            <th className="border px-4 py-2">Product ID</th>
-            <th className="border px-4 py-2">Quantity</th>
-          </tr>
-        </thead>
-        <tbody>
-          {Object.entries(data).map(([id, qty]) => (
-            <tr key={id}>
-              <td className="border px-4 py-2">{id}</td>
-              <td className="border px-4 py-2">{qty}</td>
-            </tr>
-          ))}
-        </tbody>
-      </table>
+      <section
+        className="rounded-2xl border border-slate-200 dark:border-slate-700 bg-white dark:bg-slate-900 shadow-lg shadow-black/5 divide-y divide-slate-200 dark:divide-slate-700"
+        aria-labelledby="sales-heading"
+      >
+        <header className="p-6">
+          <h1 id="sales-heading" className="text-3xl font-semibold tracking-tight text-slate-900 dark:text-slate-100">
+            Sales Dashboard
+          </h1>
+        </header>
+        <div className="p-6 text-sm text-slate-500">
+          <div className="overflow-x-auto">
+            <table className="w-full border border-slate-200 dark:border-slate-700 text-left text-slate-900 dark:text-slate-100 font-mono tabular-nums">
+              <thead className="bg-slate-50 dark:bg-slate-800">
+                <tr>
+                  <th className="border border-slate-200 dark:border-slate-700 px-4 py-2">Product ID</th>
+                  <th className="border border-slate-200 dark:border-slate-700 px-4 py-2">Quantity</th>
+                </tr>
+              </thead>
+              <tbody>
+                {Object.entries(data).map(([id, qty]) => (
+                  <tr key={id} className="text-slate-900 dark:text-slate-100">
+                    <td className="border border-slate-200 dark:border-slate-700 px-4 py-2">{id}</td>
+                    <td className="border border-slate-200 dark:border-slate-700 px-4 py-2">{qty}</td>
+                  </tr>
+                ))}
+              </tbody>
+            </table>
+          </div>
+        </div>
+      </section>
     </AdminLayout>
   );
 }

--- a/pages/charge.tsx
+++ b/pages/charge.tsx
@@ -1,60 +1,107 @@
-import { useState } from 'react';
-import Head from 'next/head';
-import Link from 'next/link';
-import { useRouter } from 'next/router';
+import { useState, Fragment } from "react";
+import Head from "next/head";
+import Link from "next/link";
+import { useRouter } from "next/router";
+import Toast from "../components/Toast";
 
 export default function Charge() {
-  const [phone, setPhone] = useState('');
-  const [amount, setAmount] = useState('');
+  const [phone, setPhone] = useState("");
+  const [amount, setAmount] = useState("");
+  const [submitting, setSubmitting] = useState(false);
+  const [toast, setToast] = useState<{ type: "success" | "error"; message: string } | null>(null);
   const router = useRouter();
 
   const submit = async (e: React.FormEvent) => {
     e.preventDefault();
-    const res = await fetch('/api/charge-requests', {
-      method: 'POST',
-      headers: { 'Content-Type': 'application/json' },
+    setSubmitting(true);
+    const res = await fetch("/api/charge-requests", {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
       body: JSON.stringify({ phoneNumber: phone, amount: Number(amount) })
     });
     if (res.ok) {
-      alert('リクエスト送信完了');
-      await router.push('/');
+      setToast({ type: "success", message: "Request sent" });
+      setPhone("");
+      setAmount("");
+      await router.push("/");
     } else {
       const err = await res.json();
-      alert(err.error || 'Failed to charge');
+      setToast({ type: "error", message: err.error || "Failed to charge" });
     }
+    setSubmitting(false);
   };
 
   return (
-    <>
-      <Head><title>Charge Balance</title></Head>
-      <div className="container mx-auto mt-4 max-w-md">
-        <div className="bg-white p-6 rounded shadow space-y-4">
-          <h1 className="text-xl font-bold">Charge Balance</h1>
-          <form onSubmit={submit} id="chargeForm" className="space-y-4">
-            <div className="space-y-1">
-              <label htmlFor="phone" className="block text-base text-gray-900">Phone Number</label>
+    <Fragment>
+      <Head>
+        <title>Charge Balance</title>
+      </Head>
+
+      <main className="mx-auto max-w-xl md:max-w-3xl lg:max-w-5xl p-6 sm:p-8 space-y-8">
+        <section
+          className="rounded-2xl border border-slate-200 dark:border-slate-700 bg-white dark:bg-slate-900 shadow-lg shadow-black/5 divide-y divide-slate-200 dark:divide-slate-700"
+          aria-labelledby="charge-heading"
+        >
+          <header className="p-6">
+            <h1 id="charge-heading" className="text-3xl font-semibold tracking-tight text-slate-900 dark:text-slate-100">
+              Charge Balance
+            </h1>
+          </header>
+
+          <form className="p-6 space-y-6 text-sm text-slate-500" onSubmit={submit}>
+            <div className="space-y-2">
+              <label htmlFor="phone" className="flex items-baseline gap-1 text-slate-900 dark:text-slate-100">
+                Phone Number<span aria-hidden="true" className="text-rose-600">*</span>
+              </label>
               <input
                 id="phone"
                 value={phone}
-                onChange={e=>setPhone(e.target.value)}
-                className="form-input w-full"
+                required
+                aria-required="true"
+                onChange={e => setPhone(e.target.value)}
+                className="h-11 w-full rounded-xl border border-slate-300 dark:border-slate-600 bg-white dark:bg-slate-900 px-4 font-mono tabular-nums text-slate-900 dark:text-slate-100 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-blue-600 focus-visible:ring-offset-2 focus-visible:ring-offset-white dark:focus-visible:ring-offset-slate-900"
               />
             </div>
-            <div className="space-y-1">
-              <label htmlFor="amount" className="block text-base text-gray-900">Amount</label>
+
+            <div className="space-y-2">
+              <label htmlFor="amount" className="flex items-baseline gap-1 text-slate-900 dark:text-slate-100">
+                Amount<span aria-hidden="true" className="text-rose-600">*</span>
+              </label>
               <input
                 id="amount"
                 type="number"
                 value={amount}
-                onChange={e=>setAmount(e.target.value)}
-                className="form-input w-full"
+                required
+                aria-required="true"
+                onChange={e => setAmount(e.target.value)}
+                className="h-11 w-full rounded-xl border border-slate-300 dark:border-slate-600 bg-white dark:bg-slate-900 px-4 font-mono tabular-nums text-slate-900 dark:text-slate-100 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-blue-600 focus-visible:ring-offset-2 focus-visible:ring-offset-white dark:focus-visible:ring-offset-slate-900"
               />
             </div>
-            <button type="submit" className="btn btn-primary w-full">Charge Request</button>
+
+            <div className="flex justify-end pt-6">
+              <button
+                type="submit"
+                disabled={submitting}
+                aria-busy={submitting}
+                className="h-11 min-w-[44px] rounded-xl bg-blue-600 px-6 text-white hover:bg-blue-700 disabled:opacity-50 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-blue-600 focus-visible:ring-offset-2 focus-visible:ring-offset-white dark:focus-visible:ring-offset-slate-900"
+              >
+                {submitting ? "Processing..." : "Charge Request"}
+              </button>
+            </div>
           </form>
-          <Link href="/" className="block text-blue-600 hover:underline">Back to Purchase</Link>
-        </div>
-      </div>
-    </>
+
+          <footer className="p-6">
+            <Link
+              href="/"
+              className="inline-flex h-11 items-center justify-center rounded-xl px-6 text-blue-600 hover:bg-blue-50 dark:hover:bg-slate-800 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-blue-600 focus-visible:ring-offset-2 focus-visible:ring-offset-white dark:focus-visible:ring-offset-slate-900"
+            >
+              Back to Purchase
+            </Link>
+          </footer>
+        </section>
+
+        {toast && <Toast type={toast.type} message={toast.message} />}
+      </main>
+    </Fragment>
   );
 }

--- a/pages/index.tsx
+++ b/pages/index.tsx
@@ -1,29 +1,25 @@
-import { useEffect, useState } from 'react';
-import Head from 'next/head';
-import Link from 'next/link';
+import { useEffect, useState, Fragment } from "react";
+import Head from "next/head";
+import Link from "next/link";
+import Toast from "../components/Toast";
 
-interface Product { product_id: string; name: string; price: number; }
+interface Product {
+  product_id: string;
+  name: string;
+  price: number;
+}
 
 export default function Home() {
-  const [phone, setPhone] = useState('');
+  const [phone, setPhone] = useState("");
   const [balance, setBalance] = useState(0);
   const [products, setProducts] = useState<Product[]>([]);
-  const [selections, setSelections] = useState<string[]>(['']);
+  const [selections, setSelections] = useState<string[]>([""]);
+  const [submitting, setSubmitting] = useState(false);
+  const [toast, setToast] = useState<{ type: "success" | "error"; message: string } | null>(null);
 
-  useEffect(() => { fetch('/api/products').then(r => r.json()).then(setProducts); }, []);
-
-  const total = selections.reduce((sum, id) => {
-    const p = products.find(p => p.product_id === id);
-    return p ? sum + p.price : sum;
-  }, 0);
-
-  const addProduct = () => setSelections([...selections, '']);
-
-  const changeSelection = (idx: number, val: string) => {
-    const next = selections.slice();
-    next[idx] = val;
-    setSelections(next);
-  };
+  useEffect(() => {
+    fetch("/api/products").then(r => r.json()).then(setProducts);
+  }, []);
 
   const loadBalance = async () => {
     if (!phone) return;
@@ -35,85 +31,158 @@ export default function Home() {
   useEffect(() => {
     loadBalance();
     const handleFocus = () => loadBalance();
-    window.addEventListener('focus', handleFocus);
-    return () => window.removeEventListener('focus', handleFocus);
+    window.addEventListener("focus", handleFocus);
+    return () => window.removeEventListener("focus", handleFocus);
   }, [phone]);
+
+  const changeSelection = (idx: number, value: string) => {
+    const next = [...selections];
+    next[idx] = value;
+    setSelections(next);
+  };
+
+  const addProduct = () => setSelections([...selections, ""]);
+
+  const total = selections.reduce((sum, id) => {
+    const p = products.find(p => p.product_id === id);
+    return p ? sum + p.price : sum;
+  }, 0);
 
   const handleSubmit = async (e: React.FormEvent) => {
     e.preventDefault();
+    setSubmitting(true);
     const itemsMap = new Map<string, number>();
-    selections.forEach(id => { if (id) itemsMap.set(id, (itemsMap.get(id) || 0) + 1); });
+    selections.forEach(id => {
+      if (id) itemsMap.set(id, (itemsMap.get(id) || 0) + 1);
+    });
     const items = Array.from(itemsMap.entries()).map(([productId, quantity]) => ({ productId, quantity }));
-    const res = await fetch('/api/purchase', {
-      method: 'POST',
-      headers: { 'Content-Type': 'application/json' },
+    const res = await fetch("/api/purchase", {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
       body: JSON.stringify({ phoneNumber: phone, items })
     });
     if (res.ok) {
       const data = await res.json();
       setBalance(data.balance);
-      setSelections(['']);
-      alert('Purchase recorded');
+      setSelections([""]);
+      setToast({ type: "success", message: "Purchase recorded" });
     } else {
       const err = await res.json();
-      alert(err.error || 'Failed to record purchase');
+      setToast({ type: "error", message: err.error || "Failed to record purchase" });
     }
+    setSubmitting(false);
   };
 
   return (
-    <>
+    <Fragment>
       <Head>
         <title>Shop</title>
       </Head>
-      <div className="mx-auto mt-4 max-w-md p-6 bg-white rounded shadow">
-        <h1 className="text-xl font-bold mb-4">Buy Products</h1>
-        <form onSubmit={handleSubmit} id="purchaseForm" className="space-y-4">
-          <div>
-            <label htmlFor="phone" className="block mb-1 text-base text-gray-900">Phone Number</label>
-            <input
-              type="tel"
-              id="phone"
-              value={phone}
-              onChange={e=>setPhone(e.target.value)}
-              onBlur={loadBalance}
-              className="w-full p-2 border border-gray-300 rounded focus:outline-none focus:ring-1 focus:ring-blue-500 focus:border-blue-500"
-            />
-          </div>
-          <div>Balance: ¥<span id="balance">{balance}</span></div>
-          {selections.map((sel, i) => (
-            <div key={i}>
-              <select
-                value={sel}
-                onChange={e=>changeSelection(i, e.target.value)}
-                className="w-full p-2 border border-gray-300 rounded focus:outline-none focus:ring-1 focus:ring-blue-500 focus:border-blue-500"
-              >
-                <option value="">選択</option>
-                {products.map(p => (
-                  <option key={p.product_id} value={p.product_id}>{p.name} ¥{p.price}</option>
-                ))}
-              </select>
+
+      <main className="mx-auto max-w-xl md:max-w-3xl lg:max-w-5xl p-6 sm:p-8 space-y-8">
+        <section
+          className="rounded-2xl border border-slate-200 dark:border-slate-700 bg-white dark:bg-slate-900 shadow-lg shadow-black/5 divide-y divide-slate-200 dark:divide-slate-700"
+          aria-labelledby="purchase-heading"
+        >
+          <header className="p-6">
+            <h1 id="purchase-heading" className="text-3xl font-semibold tracking-tight text-slate-900 dark:text-slate-100">
+              Buy Products
+            </h1>
+          </header>
+
+          <form
+            className="p-6 space-y-6 text-sm text-slate-500"
+            onSubmit={handleSubmit}
+            aria-describedby="balance total"
+          >
+            <div className="space-y-2">
+              <label htmlFor="phone" className="flex items-baseline gap-1 text-slate-900 dark:text-slate-100">
+                Phone Number<span aria-hidden="true" className="text-rose-600">*</span>
+              </label>
+              <input
+                id="phone"
+                type="tel"
+                value={phone}
+                required
+                aria-required="true"
+                aria-describedby="phone-help"
+                onChange={e => setPhone(e.target.value)}
+                onBlur={loadBalance}
+                className="h-11 w-full rounded-xl border border-slate-300 dark:border-slate-600 bg-white dark:bg-slate-900 px-4 font-mono tabular-nums text-slate-900 dark:text-slate-100 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-blue-600 focus-visible:ring-offset-2 focus-visible:ring-offset-white dark:focus-visible:ring-offset-slate-900"
+              />
+              <p id="phone-help" className="text-xs text-slate-500">
+                Enter customer phone number.
+              </p>
             </div>
-          ))}
-          <button
-            type="button"
-            id="addProduct"
-            onClick={addProduct}
-            className="px-3 py-2 text-sm text-blue-600 border border-blue-600 rounded hover:bg-blue-50"
-          >
-            Add Product
-          </button>
-          <div className={`font-bold ${balance < total ? 'text-red-500' : ''}`}>
-            Total: ¥<span id="total">{total}</span>
-          </div>
-          <button
-            type="submit"
-            className="px-4 py-2 text-lg bg-blue-600 text-white rounded hover:bg-blue-700"
-          >
-            Purchase
-          </button>
-        </form>
-        <Link href="/charge" className="block mt-4 text-blue-600 hover:underline">Money Charge</Link>
-      </div>
-    </>
+
+            <p id="balance" className="font-mono tabular-nums text-slate-900 dark:text-slate-100">
+              Balance: ¥{balance}
+            </p>
+
+            {selections.map((sel, i) => (
+              <div key={i} className="space-y-2">
+                <label htmlFor={`product-${i}`} className="sr-only">
+                  Product {i + 1}
+                </label>
+                <select
+                  id={`product-${i}`}
+                  value={sel}
+                  required={i === 0}
+                  aria-required={i === 0 ? "true" : undefined}
+                  onChange={e => changeSelection(i, e.target.value)}
+                  className="h-11 w-full rounded-xl border border-slate-300 dark:border-slate-600 bg-white dark:bg-slate-900 px-4 text-slate-900 dark:text-slate-100 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-blue-600 focus-visible:ring-offset-2 focus-visible:ring-offset-white dark:focus-visible:ring-offset-slate-900"
+                >
+                  <option value="">選択</option>
+                  {products.map(p => (
+                    <option key={p.product_id} value={p.product_id}>
+                      {p.name} ¥{p.price}
+                    </option>
+                  ))}
+                </select>
+              </div>
+            ))}
+
+            <button
+              type="button"
+              onClick={addProduct}
+              className="h-11 min-w-[44px] rounded-xl border border-blue-600 text-blue-600 px-6 hover:bg-blue-50 dark:hover:bg-slate-800 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-blue-600 focus-visible:ring-offset-2 focus-visible:ring-offset-white dark:focus-visible:ring-offset-slate-900"
+            >
+              Add Product
+            </button>
+
+            <p
+              id="total"
+              className={`font-mono tabular-nums font-semibold ${
+                balance < total ? "text-rose-600" : "text-slate-900 dark:text-slate-100"
+              }`}
+            >
+              Total: ¥{total}
+            </p>
+
+            <div className="flex justify-end pt-6">
+              <button
+                type="submit"
+                disabled={submitting}
+                aria-busy={submitting}
+                className="h-11 min-w-[44px] rounded-xl bg-blue-600 px-6 text-white hover:bg-blue-700 disabled:opacity-50 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-blue-600 focus-visible:ring-offset-2 focus-visible:ring-offset-white dark:focus-visible:ring-offset-slate-900"
+              >
+                {submitting ? "Processing..." : "Purchase"}
+              </button>
+            </div>
+          </form>
+
+          <footer className="p-6">
+            <Link
+              href="/charge"
+              className="inline-flex h-11 items-center justify-center rounded-xl px-6 text-blue-600 hover:bg-blue-50 dark:hover:bg-slate-800 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-blue-600 focus-visible:ring-offset-2 focus-visible:ring-offset-white dark:focus-visible:ring-offset-slate-900"
+            >
+              Money Charge
+            </Link>
+          </footer>
+        </section>
+
+        {toast && <Toast type={toast.type} message={toast.message} />}
+      </main>
+    </Fragment>
   );
 }


### PR DESCRIPTION
## Summary
- adopt card-based layouts and accessible forms across purchase and charge flows
- create reusable toast component for success and error feedback
- modernize admin pages with cohesive Tailwind design tokens

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68ac757ae4e8832ba7744d02b87b9790